### PR TITLE
dealt with illegal whitespace in 2003 PSID file

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,3 +9,5 @@ License: GPL (>= 2)
 URL: https://github.com/ajdamico/SAScii
 Depends: R (>= 2.14)
 LazyLoad: Yes
+Imports: 
+	stringr

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -1,0 +1,2 @@
+export(parse.SAScii)
+export(read.SAScii)

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -1,2 +1,3 @@
 export(parse.SAScii)
 export(read.SAScii)
+export(SAScii_fork)

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -1,3 +1,2 @@
 export(parse.SAScii)
 export(read.SAScii)
-export(SAScii_fork)

--- a/R/parse.SAScii.R
+++ b/R/parse.SAScii.R
@@ -10,7 +10,7 @@ function( sas_ri , beginline = 1 , lrecl = NULL ){
 	##if the SAS code includes more than one INPUT, start at the user-specified beginline
 	SASinput <- SASinput[ beginline:length(SASinput) ]
 	
-	SASinput <- toupper( str_trim(SASinput) )
+	SASinput <- toupper( stringr::str_trim(SASinput) )
 
 	#remote all /* and */ from the code
 	SASinput <- SAS.uncomment( SASinput , "/*" , "*/" )

--- a/R/parse.SAScii.R
+++ b/R/parse.SAScii.R
@@ -10,7 +10,7 @@ function( sas_ri , beginline = 1 , lrecl = NULL ){
 	##if the SAS code includes more than one INPUT, start at the user-specified beginline
 	SASinput <- SASinput[ beginline:length(SASinput) ]
 	
-	SASinput <- toupper( SASinput )
+	SASinput <- toupper( str_trim(SASinput) )
 
 	#remote all /* and */ from the code
 	SASinput <- SAS.uncomment( SASinput , "/*" , "*/" )

--- a/R/read.SAScii.R
+++ b/R/read.SAScii.R
@@ -10,6 +10,10 @@ withWarnings <- function(expr) {
      withCallingHandlers(expr, warning = wHandler)
 } 
 
+SAScii_fork <- function(){
+	return(TRUE)
+}
+
 
 read.SAScii <- 
 function( fn , sas_ri , beginline = 1 , buffersize = 50 , zipped = F , n = -1 , intervals.to.print = 1000 , lrecl = NULL , skip.decimal.division = NULL ){

--- a/R/read.SAScii.R
+++ b/R/read.SAScii.R
@@ -10,10 +10,6 @@ withWarnings <- function(expr) {
      withCallingHandlers(expr, warning = wHandler)
 } 
 
-SAScii_fork <- function(){
-	return(TRUE)
-}
-
 
 read.SAScii <- 
 function( fn , sas_ri , beginline = 1 , buffersize = 50 , zipped = F , n = -1 , intervals.to.print = 1000 , lrecl = NULL , skip.decimal.division = NULL ){

--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# Fork of SAScii 
+
+this is a fork of the SAScii R package repo.


### PR DESCRIPTION
hi!
there was a recent update of psid files. if you try to read the 2003 family file there is an illegal whitespace and `toupper` fails. I added the `stringr` package as a dependency to deal with this.
