### PR TITLE
Add functionality to handle different encodings in SAS comments

### DIFF
--- a/R/SAS.uncomment.R
+++ b/R/SAS.uncomment.R
@@ -1,9 +1,14 @@
 SAS.uncomment <- 
-function( SASinput , starting.comment , ending.comment ){
+function( SASinput , starting.comment , ending.comment, encoding=NULL ){
 
 	#remove /* */
 	for ( i in 1:length(SASinput) ){
 		
+        # coerce the line to the desired encoding if one is provided
+        if (!is.null(encoding)) {
+            Encoding(SASinput[i]) <- encoding
+        }
+                
 		#test if the line contains a slash_asterisk (or any opening comment character)
 		slash_asterisk <- unlist( gregexpr( starting.comment , SASinput[ i ] , fixed = T ) )
 		
@@ -47,4 +52,3 @@ function( SASinput , starting.comment , ending.comment ){
 
 	SASinput
 }
-

--- a/R/read.SAScii.R
+++ b/R/read.SAScii.R
@@ -182,4 +182,3 @@ function( fn , sas_ri , beginline = 1 , buffersize = 50 , zipped = F , n = -1 , 
 
 	SASfile
 }
-


### PR DESCRIPTION
This is the second of two pull requests I'm making to make the [lodown](https://github.com/ajdamico/lodown) package run for the Pesquisa Mensal de Emprego (PME).

I added an option to the `SAS.uncomment` function to allow it to coerce lines of the SAS script into a user-specified encoding. This circumvents string errors which occur when the SAS script you are trying to parse is not encoded in UTF-8. 

Please note that I'm not an expert on the technical details of this stuff and made these changes to get lodown running for me in as short a time as possible. I hope these changes will be helpful to other users too, but they may well have limitations I haven't explored.

Edit: see the first pull request [here](https://github.com/ajdamico/lodown/pull/159).